### PR TITLE
Initial draft for standalone Vault Plugin installation

### DIFF
--- a/docs/k8s-deployment.md
+++ b/docs/k8s-deployment.md
@@ -1,0 +1,309 @@
+
+# Kubernetes Deployment
+
+The following guide walks through the steps to deploy the Vault Plugin within a Kubernetes environment.
+The steps are divided into two sections they first covers the deployment of a Redis Enterprise cluster through the Redis Enterprise K8s Operator 
+and the second covers the deployment of Vault and the Redis Vault Plugin.  Where appropriate supportive links are provided within each section.
+
+Note: This guide is aimed at the provsioning of a development k8s based environment to execute the Vault Plugin.  
+It is not a guide to provision a production grade environment. 
+
+
+
+### Prerequisites
+
+The following prerequisites have been used during the provisioning of Redis Enterprise and HashiCorp Vault on Kubernetes, (k8s).
+
+* **k8s platform**
+  * Docker Desktop has been used with 6 CPUs, 10GB Memory and 2GB Swap.  It was observed that 10GB of disk storage was used.
+* **kubectl**
+  * Installed and configured with access to k8s platform.
+* **jq**
+  * Used to extract required values from JSON returned by cli tools.
+* **helm**
+  * Used to provision HashiCorp Vault into k8s.  HashiCorp Vault chart supports Helm v3 and above.
+  
+
+## Deploying Redis Enterprise to K8s
+
+The primary method to deploy a Redis Enterprise cluster to K8s is through the Redis Enterprise Operator.
+Using the Operator is the most efficient way to deploy and maintain a cluster.
+
+More information about the Redis Enterprise Operator can be found through the following link.
+* [Redis Enterprise Kubernetes Operator-based Architecture](https://docs.redislabs.com/latest/platforms/kubernetes/concepts/operator)
+
+### Operator
+
+The Redis Enterprise Operator k8s configuration can be downloaded the RedisLabs GitHub account.  The following commands locate the latest version of the 
+Operator, download the appropriate k8s YAML file and then apply the configuration through kubectl to the local k8s environment.
+
+```sh
+$ export VERSION=`curl --silent https://api.github.com/repos/RedisLabs/redis-enterprise-k8s-docs/releases/latest | grep tag_name | awk -F'"' '{print $4}'`
+$ curl --silent -O https://raw.githubusercontent.com/RedisLabs/redis-enterprise-k8s-docs/$VERSION/bundle.yaml 
+$ cat bundle.yaml | kubectl apply -f -
+
+role.rbac.authorization.k8s.io/redis-enterprise-operator created
+rolebinding.rbac.authorization.k8s.io/redis-enterprise-operator created
+serviceaccount/redis-enterprise-operator created
+Warning: apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
+customresourcedefinition.apiextensions.k8s.io/redisenterpriseclusters.app.redislabs.com created
+deployment.apps/redis-enterprise-operator created
+customresourcedefinition.apiextensions.k8s.io/redisenterprisedatabases.app.redislabs.com created
+```
+After the Operator has been successfully install to k8s CRDs representing the a cluster and database can be used.
+The operator is now installed and ready for cluster and database resource definitions to be applied. 
+
+### Cluster
+
+After the Redis Enterprise Operator has been installed a cluster is created through the RedisEnterpriseCluster resource.  
+The following command creates a cluster called `test-cluster` with a single node.
+
+```sh
+$ cat <<EOF | kubectl apply -f -
+apiVersion: "app.redislabs.com/v1"
+kind: "RedisEnterpriseCluster"
+metadata:
+  name: "test-cluster"
+spec:
+  nodes: 1
+  redisEnterpriseNodeResources:
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+    requests:
+      cpu: 25m
+      memory: 2Gi
+EOF
+
+redisenterprisecluster.app.redislabs.com/test-cluster created
+```
+
+A cluster will be present within the default namespace within the k8s environment.  A database can be provisioned within the cluster.
+
+
+### Database
+
+Once the Redis Enterprise Cluster has been created then a database can be created through a RedisEnterpriseDatabase resource.  
+The following command creates a database called `mydb` with a role called `DB Member`.
+
+```sh
+$ cat <<EOF | kubectl apply -f -
+apiVersion: app.redislabs.com/v1alpha1
+kind: RedisEnterpriseDatabase
+metadata:
+  name: mydb
+spec:
+  memory: 100MB
+  redisEnterpriseCluster:
+    name: test-cluster
+  rolesPermissions:
+  - type: redis-enterprise
+    role: "DB Member"
+    acl: "Not Dangerous"
+EOF
+
+redisenterprisedatabase.app.redislabs.com/mydb created
+```
+
+The database will have been provisioned within the cluster and credentials a set of Administrator credentials will have been created.
+
+### Service
+
+Following the creation of the cluster and the database external k8s access can be achieved through a provioned service.  This will allow 
+the Vault Plugin's tests to use the provisioned Redis Enterprise cluster.
+
+The following command provisions a service to expose the cluster externally to k8s.
+
+```sh
+$ cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: redis-enterprise
+    redis.io/cluster: test-cluster
+  name: external-access
+spec:
+  ports:
+  - name: api
+    port: 9443
+    protocol: TCP
+    targetPort: 9443
+    nodePort: 30000
+  selector:
+    app: redis-enterprise
+    redis.io/cluster: test-cluster
+    redis.io/role: node
+  sessionAffinity: None
+  type: NodePort
+EOF
+
+service/test-cluster-service created
+```
+
+### Testing Cluster with Vault Plugin Tests
+
+Before executing the Vault plugin tests the state of the cluster and the status of the database can be checked.
+After the database has been provisioned the cluster will return a state of `running` and the database will report a state 
+of `active`.
+
+```sh
+$ kubectl get redisenterpriseclusters.app.redislabs.com test-cluster --output jsonpath='{.status.state}'
+Running
+
+$ kubectl get redisenterprisedatabase.app.redislabs.com mydb --output jsonpath='{.status.status}'
+Active
+```
+
+Now the database is active the Vault Plugin tests can executes. For the tests to executed a set of credentials will need to be extracted from k8s. 
+The following command will extract the username, password and node port and placed them in environment variable to be discovered by the executing tests.
+
+```sh
+$ export TEST_USERNAME=$(kubectl get secret test-cluster -o jsonpath='{.data.username}' | base64 -d)
+$ export TEST_PASSWORD=$(kubectl get secret test-cluster -o jsonpath='{.data.password}' | base64 -d)
+$ export TEST_DB_URL=https://localhost:$(kubectl get svc external-access --output jsonpath='{.spec.ports[].nodePort}')
+
+$ make test-acc
+```
+
+Alongside the execution of the tests the Redis Enterprise dashboard can be used to explore the cluster.  The following kubectl command 
+can be used to forward the local port of 8443 to the cluster's open port 8443.  After establishing the port forward, a browser can be pointed to 
+`http://localhost:8443`.  The previously mentioned username and password can be used to authenticate with the dashboard.
+
+```shell
+$ kubectl port-forward test-cluster-0 8443:8443
+```
+
+At this point in the setup a functioning Redis Enterprise cluster and database has been provision and verified through 
+the Vault Plugin tests.
+
+## Deploying Vault to K8s
+
+HashiCorp Vault can operate both internally and externally to a k8s environment.  Additionally Vault is prepackaged with a 
+number of Vault Plugins directly supported by HashiCorp.  The following sections will cover the provisoning of Vault within k8s 
+and the setup of the Vault Plugin.  It is assumed that the user has provisioned Redis Enterprise using the first part of this guide.
+
+### Vault
+
+The preferred method to provision Vault within k8s is through the official HashiCorp Helm chart.  For this guide Vault will be provisioned 
+into its own namespace and for the reminder of the guide the k8s context will be switched into a namespace called `vault`.
+
+```sh
+$ kubectl create namespace vault
+$ kubectl config set-context --current --namespace=vault
+```
+
+Helm charts allow various degrees of guided customisation for the applications they provision.  For this guide the following overriding values 
+will be used with the Vault helm chart.
+
+The key takeaway from this overriding configuration is the location of the plugins directory.  This will be used later to register the Vault Plugin binary 
+with Vault.
+
+```sh
+$ cat <<EOF>> override-values.yaml
+server:
+  standalone:
+    config: |
+      ui = true
+      listener "tcp" {
+        tls_disable = 1
+        address = "[::]:8200"
+        cluster_address = "[::]:8201"
+      }
+      storage "file" {
+        path = "/vault/data"
+      }
+      plugin_directory = "/usr/local/libexec/vault"
+  volumes:
+    - name: plugins
+      emptyDir: {}
+  volumeMounts:
+    - mountPath: /usr/local/libexec/vault
+      name: plugins
+EOF
+
+```
+
+The following command will instruct Helm to provision Vault using the previously generated YAML file.
+
+```shell
+$ helm install vault hashicorp/vault --version 0.9.1 --values ./override-values.yaml
+```
+
+Once Vault is deployed it must be initialised and unsealed.  The following commands will initialise Vault and extract 
+the root token and unseal key.  Finally Vault is unsealed using the key and Vault's status can be checked.
+
+```shell
+$ kubectl exec vault-0 -- vault operator init -key-shares=1 -key-threshold=1 -format=json > cluster-keys.json
+$ VAULT_UNSEAL_KEY=$(cat cluster-keys.json | jq -r ".unseal_keys_b64[]")
+$ kubectl exec vault-0 -- vault operator unseal $VAULT_UNSEAL_KEY
+
+$ kubectl exec -n vault vault-0 -- vault status
+```
+
+Vault is now ready to accept the Redis Enterprise Vault Plugin.
+
+### Vault Plugin
+
+After the Vault instance has been unsealed the Redis Enterprise Vault Plugin can be installed.  Firstly the plugin binary is built
+and placed in the `bin` directory.  There will be two binaries the first called `vault-plugin-database-redisenterprise` and
+the second called `vault-plugin-database-redisenterprise_linux_amd64`.  The `vault-plugin-database-redisenterprise_linux_amd64` 
+binary is copied to the vault mounted volume.
+
+```shell
+$ make build
+$ kubectl cp ../bin/vault-plugin-database-redisenterprise_linux_amd64 vault-0:/usr/local/libexec/vault
+```
+
+The root token is needed to log into the Vault instance and this is present in the `cluster-keys.json` file created earlier.
+It can be extract through the following command.
+
+```shell
+$ cat cluster-keys.json | jq -r ".root_token"
+```
+
+To register the vault plugin first open up a terminal prompt inside the vault container and use the `vault login` command
+together with the root token.  From this point on the following commands will be executed inside the Vault container.
+
+```sh
+$ kubectl exec --stdin=true --tty=true vault-0 -- /bin/sh
+$ vault login
+```
+
+The vault plugin binary must be registered in the Vault catalog before it can be used.  To do this the SHA of the binary 
+must be known and supplied with the location of the binary. A success message will indicate that the plugin is registered.
+
+NOTE:  The success message only gives confirmation the plugin is registered, but does not verify that the SHA value matches the binary.  
+If this is wrong then Vault will communicate this through later commands.
+
+```shell
+$ export REDIS_VAULT_PLUGIN_SHA=$(sha256sum /usr/local/libexec/vault/vault-plugin-database-redisenterprise_linux_amd64 | awk '{ print $1 }')
+$ vault write sys/plugins/catalog/database/redisenterprise-database-plugin command=vault-plugin-database-redisenterprise_linux_amd64 sha256=$REDIS_VAULT_PLUGIN_SHA
+Success! Data written to: sys/plugins/catalog/database/redisenterprise-database-plugin
+```
+
+Enable to database secrets engine
+
+```shell
+$ vault secrets enable database
+Success! Enabled the database secrets engine at: database/
+```
+
+Next the registered plugin is configured with the details to locate and authenticate with the Redis Enterprise Cluster.
+
+```shell
+$ vault write database/config/redis-mydb plugin_name="redisenterprise-database-plugin" url="https://external-access.default.svc.cluster.local:9443" allowed_roles="*" database=mydb username=<PROVISIONED USERNAME> password=<PROVISIONED PASSWORD>
+```
+
+Following a successful authentication with the Redis Enterprise cluster Vault must be configured with a creation statement to use through the Vault Plugin.
+
+```shell
+$ vault write database/roles/mydb db_name=redis-mydb creation_statements="{\"role\":\"DB Member\"}" default_ttl=3m max_ttl=5m
+```
+
+The final step is to verify the registration and configuration of the plugin through Vault.  The following `vault read` command will 
+generate a new user against the Redis Enterprise cluster.
+
+```shell
+$ vault read database/creds/mydb
+```

--- a/docs/vault-deployment.md
+++ b/docs/vault-deployment.md
@@ -1,0 +1,107 @@
+
+# Redis Enterprise Database Secrets Engine
+
+This secrets engine is a part of the Database Secrets Engine. If you have not read the [Database Backend](https://www.vaultproject.io/docs/secrets/databases) 
+page, please do so now as it explains how to set up the database backend and gives an overview of how the engine functions.
+
+Redis Enterprise is a partner supported plugin for the database secrets engine. It is capable of dynamically generating 
+credentials based on configured roles for Redis Enterprise clusters.
+
+## Capabilities
+
+|Plugin Name	Root | Credential Rotation | Dynamic Roles | Static Roles|
+|:----------------:|:-------------------:|:-------------:|:-----------:|
+| Customizable (see: [Custom Plugins](https://www.vaultproject.io/docs/secrets/databases/custom)) | Yes | Yes | Yes |
+
+## Setup
+The Redis Enterprise database plugin is not bundled in the core Vault code tree and can be found at its own
+git repository here: https://github.com/RedisLabs/vault-plugin-database-redis-enterprise
+
+For linux/amd64, pre-built binaries can be found at the [releases page](http://TBC)
+
+**1. Enable the database secrets engine if it is not already enabled:**
+
+```shell
+$ vault secrets enable database
+Success! Enabled the database secrets engine at: database/
+```
+
+By default, the secrets engine will enable at the name of the engine. 
+To enable the secrets engine at a different path, use the `-path` argument.
+
+**2. Download and register the plugin:**
+
+```shell
+$ vault write sys/plugins/catalog/database/vault-plugin-database-redisenterprise \
+    sha256="..." \
+    command=vault-plugin-database-redisenterprise
+Success! Data written to: sys/plugins/catalog/database/vault-plugin-database-redisenterprise
+```
+
+**3. Configure Vault with the proper plugin and connection information:**
+
+```shell
+$ vault write database/config/redis-mydb plugin_name="vault-plugin-database-redisenterprise" \
+    url="https://localhost:9443" \
+    allowed_roles="*" \
+    database={{database}} \
+    username={{username}} \
+    password={{password}}
+```
+
+**Note:** It is highly recommended that you immediately rotate the "root" user's password. 
+(see [Rotate Root Credentials](https://www.vaultproject.io/api/secret/databases#rotate-root-credentials)). 
+This will ensure that only Vault is able to access the "root" user that Vault uses to manipulate dynamic & static credentials.
+
+**Use caution:** the root user's password will not be accessible once rotated so it is highly recommended that you create 
+a user for Vault to utilize rather than using the actual root user.
+
+**4. Configure a role that maps a name in Vault to an Redis Enterprise role statement to execute:**
+
+```shell
+$ vault write database/roles/redis-mydb \
+  db_name=redis-mydb \
+  creation_statements='{"role":"DB Member"}' \
+  default_ttl=3m \
+  max_ttl=5m
+Success! Data written to: database/roles/my-role
+```
+
+**Note:** The creation_statements may be specified in a file and interpreted by the Vault CLI using the @ symbol:
+
+```shell
+$ vault write database/roles/redis-mydb \
+    db_name=redis-mydb \
+    creation_statements=@creation.json \
+    default_ttl=3m \
+    max_ttl=5m
+    ...
+```
+
+See the [Commands](https://www.vaultproject.io/docs/commands#files) docs for more details.
+
+## Usage
+
+### Dynamic Credentials
+
+After the secrets engine is configured and a user/machine has a Vault token with the proper permission, 
+it can generate credentials.
+
+Generate a new credential by reading from the /creds endpoint with the name of the role:
+
+```shell
+$ vault read database/creds/redis-mydb
+Key                Value
+---                -----
+lease_id           database/creds/redis-mydb/L7aTdIYx3CXk3DSqw76JcLor
+lease_duration     3m
+lease_renewable    true
+password           GP-OsO9BpgtjH8PK6MKU
+username           v_root_redis-mydb_bh3d1ha82e46opgaarto_1613047913
+```
+
+**Note**: As Redis Enterprise does not support automatically expiring the users created for a dynamic credential, these users may still be active if Vault is unable to communicate with Redis Enterprise when the leased secret expires as the plugin will be unable to delete the users. You can attempt to manually revoke the leased secret by using the `vault lease revoke <lease_id>`, where the `<lease_id>` will appear in the Vault logs like `2021-02-03T10:43:47.943Z [ERROR] expiration: maximum revoke attempts reached: lease_id=database/creds/mydb/cpXGOg2hJ6uE0OWJXphXhLth`. A newly elected Vault HA leader will automatically attempt to any leases that have expired but haven't yet been deleted, so will try to delete the user again.
+## API
+
+For more information on the database secrets engine's HTTP API please see the 
+[Database secrets engine API](https://www.vaultproject.io/api/secret/databases) page.


### PR DESCRIPTION
This is an initial draft of the vault standalone instructions based on the Vault Plugin page for the Oracle plugin.  The page assumes the Redis Enterprise plugin is available in the Vault catalog and then presents a series of commands that will allow the plugin to be setup and used to generate an dynamic credential to verify the setup.

The commands have been run locally against vault in dev mode and against a running cluster.  The vault instance was local and not the container provisioned in the docker compose file.